### PR TITLE
Possibility to set ESP32 ADC attenuation during runtime

### DIFF
--- a/src/esp32/esp32_adc.c
+++ b/src/esp32/esp32_adc.c
@@ -69,6 +69,7 @@ bool esp32_set_channel_attenuation(int pin, int atten) {
   if (ci == NULL) return false;
 
   ci->atten = (adc_atten_t) atten;
+  esp32_update_channel_settings(ci);
   return true;
 }
 


### PR DESCRIPTION
Previously esp32_set_channel_attenuation() did not update ADC
channel after mgos_adc_enable(). With that change it is possible
to set ADC channel attenuation during program execution.